### PR TITLE
generator: Implement std::fmt::Display for enums

### DIFF
--- a/redfish-generator/src/main/resources/templates/model.mustache
+++ b/redfish-generator/src/main/resources/templates/model.mustache
@@ -62,6 +62,20 @@ impl Default for {{name}} {
         {{name}}::{{#defaultVariant}}{{name}}{{#type}}({{type}}::default()){{/type}}{{/defaultVariant}}
      }
 }
+
+impl std::fmt::Display for {{name}} {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        use {{name}}::*;
+        match self {
+{{#variants}}
+{{#serdeName}}
+            {{name}}{{#type}}({{type}}){{/type}} => write!(f, "{{{serdeName}}}"),
+{{/serdeName}}
+{{/variants}}
+            _ => write!(f, "{:?}", self)
+        }
+    }
+}
 {{/enumContext}}
 {{#tupleContext}}
 #[derive(Default)]


### PR DESCRIPTION
Provide a fmt::Display implementation for enums, allowing them to be converted to strings. Where a prettified serde name is defined for a given type, this is preferred, otherwise we fallback on the bare enum.

As I couldn't figure out a way to access the parent's `{{name}}` from within the variants iterator, I've worked around the clobbering issue by pulling the enum values into scope with use and matching on these directly. This is perhaps not as idiomatic as desired, but as the cases are all generated any mismatches resulting in unreachable patterns are implicitly avoided. If the mustache parser changes in the future to allow parent access, this can be tightened up.