### PR TITLE
generator: Add support for immutable property deserialization

### DIFF
--- a/generate.mk
+++ b/generate.mk
@@ -26,12 +26,16 @@ OPENAPI_DOCUMENT=api/openapi/openapi.yaml
 JAR_FILE=redfish-generator/target/redfish-codegen-0.3.1-SNAPSHOT.jar
 JVM_ARGS=-DmaxYamlCodePoints=6291456 -Dfile.encoding=UTF-8
 
+ifdef CARGO_FEATURE_CLIENT
+JAR_ARGS += -clientMode
+endif
+
 define redfish_models
 (cd $1 && java $(JVM_ARGS) -jar ../$(JAR_FILE) \
 	-specDirectory ../api \
 	-specVersion $(RELEASE_VERSION) \
 	-registryDirectory ../registry \
-	-component $2)
+	-component $2 $(JAR_ARGS))
 endef
 
 CODEGEN_DEPENDENCIES += api/openapi/openapi.yaml

--- a/redfish-generator/src/main/java/com/twardyece/dmtf/policies/ODataPropertyPolicy.java
+++ b/redfish-generator/src/main/java/com/twardyece/dmtf/policies/ODataPropertyPolicy.java
@@ -13,8 +13,10 @@ public class ODataPropertyPolicy implements IModelGenerationPolicy {
     private ODataTypeIdentifier identifier;
     private static final List<String> immutableProperties;
     private static final String ODATA_TYPE = "#/components/schemas/odata-v4_type";
-    public ODataPropertyPolicy(ODataTypeIdentifier identifier) {
+    private boolean alwaysDeserialize;
+    public ODataPropertyPolicy(ODataTypeIdentifier identifier, boolean alwaysDeserialize) {
         this.identifier = identifier;
+        this.alwaysDeserialize = alwaysDeserialize;
     }
 
     static {
@@ -34,9 +36,10 @@ public class ODataPropertyPolicy implements IModelGenerationPolicy {
             StructContext struct = entry.getValue().getContext().structContext;
             if (null != struct) {
                 for (StructContext.Property property : struct.properties) {
-                    // If the property.openapiType matches one of the few immutable properties, skip deserialization
+                    // If the property.openapiType matches one of the few immutable properties, and we are not
+                    // required to deserialize all properties, skip deserialization.
                     String openapiType = property.getOpenapiType();
-                    if (null != openapiType && !isDeserialized(openapiType)) {
+                    if (null != openapiType && !this.alwaysDeserialize && isImmutable(openapiType)) {
                         property.setIsDeserialized(false);
                     }
 
@@ -50,11 +53,7 @@ public class ODataPropertyPolicy implements IModelGenerationPolicy {
         }
     }
 
-    private static boolean isDeserialized(String propertyType) {
-        if (immutableProperties.contains(propertyType)) {
-            return false;
-        } else {
-            return true;
-        }
+    private static boolean isImmutable(String propertyType) {
+	return immutableProperties.contains(propertyType);
     }
 }

--- a/redfish-models/Cargo.toml
+++ b/redfish-models/Cargo.toml
@@ -25,3 +25,4 @@ valuable = { version = "0.1.0", features = ["derive"], optional = true }
 [features]
 default = ["valuable"]
 valuable = ['dep:valuable']
+client = []


### PR DESCRIPTION
As noted in issue #1, the redfish generator currently omits deserialization of immutable (e.g. OData) properties, which causes things like the OData ID which clients depend on to be ommitted from the serialization payload.

This introduces an alwaysDeserialize parameter for ODataPropertyPolicy, which is then set when generating code for clients (via a new -clientMode flag added to the generator). This in turn is activated by the cargo "client" feature flag passed down through the redfish-models crate.