### PR TITLE
generator: Bump swagger-parser version to 2.1.22

### DIFF
--- a/redfish-generator/pom.xml
+++ b/redfish-generator/pom.xml
@@ -26,7 +26,7 @@
     <dependency>
       <groupId>io.swagger.parser.v3</groupId>
       <artifactId>swagger-parser</artifactId>
-      <version>2.1.17-SNAPSHOT</version>
+      <version>2.1.22</version>
     </dependency>
 
     <!-- https://mvnrepository.com/artifact/commons-cli/commons-cli -->


### PR DESCRIPTION
swagger-parser 2.1.17-SNAPSHOT is no longer available, resulting in the generator maven build failing. Bump up to 2.1.22.