### PR TITLE
generator: Add FlexRay to the list of special abbreviations

### DIFF
--- a/redfish-generator/src/main/java/com/twardyece/dmtf/text/Abbreviation.java
+++ b/redfish-generator/src/main/java/com/twardyece/dmtf/text/Abbreviation.java
@@ -27,6 +27,7 @@ public class Abbreviation implements IWord {
         SPECIAL_ABBREVIATIONS.put("DHCPv4", new Abbreviation("DHCPv4"));
         SPECIAL_ABBREVIATIONS.put("DHCPv6", new Abbreviation("DHCPv6"));
         SPECIAL_ABBREVIATIONS.put("I2C", new Abbreviation("I2C"));
+        SPECIAL_ABBREVIATIONS.put("FlexRay", new Abbreviation("FlexRay"));
     }
 
     public Abbreviation(String upperCaseValue) {


### PR DESCRIPTION
Currently the case conversion erroneously converts this to 'flex_ray', so it requires special handling.

While this is currently only in a non-normative external schema still under development, simply adding it to the generator outright seemed like the easier solution compared to refactoring the generator to accept a custom additive special abbreviation list as a command line argument or creating a diverging fork of the generator.